### PR TITLE
Rename project to shelfstone in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,14 +6,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: libreplex:latest
-    container_name: libreplex
+    image: shelfstone:latest
+    container_name: shelfstone
     ports:
       - "8080:8080"
     volumes:
       - ./example_library/books:/books
       - ./example_library/config:/config
-      - libreplex_cache:/cache # Docker-managed volume for cache
+      - shelfstone_cache:/cache # Docker-managed volume for cache
     restart: unless-stopped
     environment:
       GIN_MODE: debug # Or 'release' for production
@@ -25,4 +25,4 @@ services:
     #   retries: 3
     #   start_period: 5s
 volumes:
-  libreplex_cache: {} # Defines a named volume for cache, managed by Docker
+  shelfstone_cache: {} # Defines a named volume for cache, managed by Docker

--- a/external_sources.md
+++ b/external_sources.md
@@ -1,0 +1,21 @@
+# External Sources and Considerations for "shelfstone" Renaming
+
+This document lists items that might require attention outside of this repository due to the renaming from "libreplex" to "shelfstone".
+
+## Docker Image
+
+*   **Original Image Name**: `libreplex:latest`
+*   **New Image Name**: `shelfstone:latest`
+
+**Action Required**:
+The Docker image needs to be rebuilt and pushed to a container registry under the new name `shelfstone:latest`. Any CI/CD pipelines or deployment scripts that referenced `libreplex:latest` will need to be updated to use `shelfstone:latest`.
+
+## Docker Volume
+
+*   **Original Volume Name**: `libreplex_cache`
+*   **New Volume Name**: `shelfstone_cache`
+
+**Action Required**:
+When deploying the updated `docker-compose.yaml`, Docker will create a new volume named `shelfstone_cache`. If there is important data in the old `libreplex_cache` volume that needs to be preserved, it will need to be manually migrated to the new volume. The method for this depends on the Docker host environment.
+
+**Note**: These considerations are based on the changes made in `docker-compose.yaml`. If "libreplex" was used in other contexts (e.g., cloud resource names, external monitoring dashboards, DNS entries), those will also need to be identified and updated. The current search within the repository did not find other instances.


### PR DESCRIPTION
- Replaced all instances of 'libreplex' with 'shelfstone' in `docker-compose.yaml`.
- Created `external_sources.md` to document external implications of the rename, such as Docker image and volume name changes.